### PR TITLE
Uat local

### DIFF
--- a/EmotionFrontend/src/app/bar-chart/bar-chart.component.ts
+++ b/EmotionFrontend/src/app/bar-chart/bar-chart.component.ts
@@ -199,11 +199,25 @@ export class BarChartComponent implements OnInit {
       },
       y: {
         beginAtZero: true,
+        min: 0,
+        max: 5,
         ticks: {
           font: {
             size: 18,
           },
-          stepSize: 0.5,
+          stepSize: 1,
+          callback: function(value: any) {
+            // Map numeric values to intensity labels
+            const labels: { [key: number]: string } = {
+              0: '0 (None)',
+              1: '1 (Very Weak)',
+              2: '2 (Weak)',
+              3: '3 (Moderate)',
+              4: '4 (Strong)',
+              5: '5 (Very Strong)'
+            };
+            return labels[value] || value;
+          }
         },
       },
     },
@@ -217,6 +231,25 @@ export class BarChartComponent implements OnInit {
         },
         onClick: () => {},
       },
+      tooltip: {
+        callbacks: {
+          label: function(context: any) {
+            const value = context.parsed.y;
+            const labels: { [key: string]: string } = {
+              '0': 'None',
+              '1': 'Very Weak',
+              '2': 'Weak',
+              '3': 'Moderate',
+              '4': 'Strong',
+              '5': 'Very Strong'
+            };
+            // Find the closest intensity level
+            const roundedValue = Math.round(value);
+            const label = labels[roundedValue.toString()] || '';
+            return `${context.dataset.label}: ${value.toFixed(2)} (${label})`;
+          }
+        }
+      }
     },
   };
 

--- a/EmotionFrontend/src/app/bar-chart/bar-chart.component.ts
+++ b/EmotionFrontend/src/app/bar-chart/bar-chart.component.ts
@@ -206,7 +206,7 @@ export class BarChartComponent implements OnInit {
             size: 18,
           },
           stepSize: 1,
-          callback: function(value: any) {
+          callback: function (value: any) {
             // Map numeric values to intensity labels
             const labels: { [key: number]: string } = {
               0: '0 (None)',
@@ -214,10 +214,10 @@ export class BarChartComponent implements OnInit {
               2: '2 (Weak)',
               3: '3 (Moderate)',
               4: '4 (Strong)',
-              5: '5 (Very Strong)'
+              5: '5 (Very Strong)',
             };
             return labels[value] || value;
-          }
+          },
         },
       },
     },
@@ -233,7 +233,7 @@ export class BarChartComponent implements OnInit {
       },
       tooltip: {
         callbacks: {
-          label: function(context: any) {
+          label: function (context: any) {
             const value = context.parsed.y;
             const labels: { [key: string]: string } = {
               '0': 'None',
@@ -241,15 +241,15 @@ export class BarChartComponent implements OnInit {
               '2': 'Weak',
               '3': 'Moderate',
               '4': 'Strong',
-              '5': 'Very Strong'
+              '5': 'Very Strong',
             };
             // Find the closest intensity level
             const roundedValue = Math.round(value);
             const label = labels[roundedValue.toString()] || '';
             return `${context.dataset.label}: ${value.toFixed(2)} (${label})`;
-          }
-        }
-      }
+          },
+        },
+      },
     },
   };
 

--- a/EmotionFrontend/src/app/popup-window/popup-window.component.html
+++ b/EmotionFrontend/src/app/popup-window/popup-window.component.html
@@ -29,9 +29,7 @@
           >
             ⭐&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- Very Weak<br />
             ⭐⭐&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- Weak<br />
-            ⭐⭐⭐&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- Moderate<br />
-            ⭐⭐⭐⭐&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- Strong<br />
-            ⭐⭐⭐⭐⭐&nbsp;- Very Strong
+            ⭐⭐⭐&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;- Moderate
           </d-form-label>
           <d-form-label>I feel</d-form-label>
           <d-form-control [style.width.%]="80">
@@ -76,7 +74,7 @@
                     [(ngModel)]="item.value"
                     color="#fac20a"
                     [allowHalf]="false"
-                    [count]="5"
+                    [count]="3"
                   ></d-rate
                   >{{ item.value }}
                 </d-form-control>

--- a/EmotionFrontend/src/app/scrollspy/scrollspy.component.ts
+++ b/EmotionFrontend/src/app/scrollspy/scrollspy.component.ts
@@ -74,7 +74,7 @@ export class ScrollspyComponent implements OnInit {
   }
 
   convertTimestampToDate(timestamp: string): string {
-    const ms = Number(timestamp) * 1000;
+    const ms = Number(timestamp);
     return new Date(ms).toLocaleString(); // or use Angular DatePipe if needed
   }
 

--- a/EmotionFrontend/src/app/star-rating/star-rating.component.ts
+++ b/EmotionFrontend/src/app/star-rating/star-rating.component.ts
@@ -11,6 +11,4 @@ export class StarRatingComponent {
   @Input() intensity_1star: number | undefined;
   @Input() intensity_2star: number | undefined;
   @Input() intensity_3star: number | undefined;
-  @Input() intensity_4star: number | undefined;
-  @Input() intensity_5star: number | undefined;
 }

--- a/EmotionFrontend/src/app/test-noterating/test-noterating.component.ts
+++ b/EmotionFrontend/src/app/test-noterating/test-noterating.component.ts
@@ -34,8 +34,6 @@ export class TestNoteratingComponent implements OnInit {
         intensity_1star: number;
         intensity_2star: number;
         intensity_3star: number;
-        intensity_4star: number;
-        intensity_5star: number;
       };
     };
   } = {};
@@ -221,8 +219,6 @@ export class TestNoteratingComponent implements OnInit {
             intensity_1star: 0,
             intensity_2star: 0,
             intensity_3star: 0,
-            intensity_4star: 0,
-            intensity_5star: 0,
           };
         }
 
@@ -232,10 +228,6 @@ export class TestNoteratingComponent implements OnInit {
           acc[noteId][emotionId].intensity_2star += 1;
         } else if (intensity === 3) {
           acc[noteId][emotionId].intensity_3star += 1;
-        } else if (intensity === 4) {
-          acc[noteId][emotionId].intensity_4star += 1;
-        } else if (intensity === 5) {
-          acc[noteId][emotionId].intensity_5star += 1;
         }
       });
 
@@ -253,9 +245,7 @@ export class TestNoteratingComponent implements OnInit {
       const key = `intensity_${intensity}star` as
         | 'intensity_1star'
         | 'intensity_2star'
-        | 'intensity_3star'
-        | 'intensity_4star'
-        | 'intensity_5star';
+        | 'intensity_3star';
       return noteData[emotionId][key] || 0;
     }
     return 0;
@@ -265,7 +255,7 @@ export class TestNoteratingComponent implements OnInit {
     const noteData = this.intensityCounts[noteId];
     if (noteData && noteData[emotionId]) {
       // Determine the highest intensity level
-      const intensities = [1, 2, 3, 4, 5];
+      const intensities = [1, 2, 3];
       let maxIntensity = 0;
 
       for (const intensity of intensities) {
@@ -304,8 +294,6 @@ export class TestNoteratingComponent implements OnInit {
           const noteIdA = a.note._id;
           const emotionIdA = a.ratings[0]?.emotionId;
           const intensityCountA =
-            this.getIntensityCount(noteIdA, emotionIdA, 5) * 5 +
-            this.getIntensityCount(noteIdA, emotionIdA, 4) * 4 +
             this.getIntensityCount(noteIdA, emotionIdA, 3) * 3 +
             this.getIntensityCount(noteIdA, emotionIdA, 2) * 2 +
             this.getIntensityCount(noteIdA, emotionIdA, 1);
@@ -313,8 +301,6 @@ export class TestNoteratingComponent implements OnInit {
           const noteIdB = b.note._id;
           const emotionIdB = b.ratings[0]?.emotionId;
           const intensityCountB =
-            this.getIntensityCount(noteIdB, emotionIdB, 5) * 5 +
-            this.getIntensityCount(noteIdB, emotionIdB, 4) * 4 +
             this.getIntensityCount(noteIdB, emotionIdB, 3) * 3 +
             this.getIntensityCount(noteIdB, emotionIdB, 2) * 2 +
             this.getIntensityCount(noteIdB, emotionIdB, 1);


### PR DESCRIPTION
This pull request updates the emotion intensity rating system across several components to standardize ratings to a 3-level scale (1–3) instead of the previous 5-level scale (1–5). It also improves the bar chart display by mapping numeric values to descriptive labels and enhances tooltips for better user understanding. The changes simplify the codebase and user interface by removing unused 4-star and 5-star intensity logic and updating UI elements accordingly.

**Emotion Intensity Rating System Simplification**

* All logic and data structures in `TestNoteratingComponent`, `StarRatingComponent`, and related UI have been updated to use only 1–3 star intensities, removing support for 4-star and 5-star ratings. This includes changes to property definitions, aggregation logic, and sorting calculations. [[1]](diffhunk://#diff-83788f5a048fe5dfe5c1fb462b014bae9b423de9d3a27b4bd3ace7805c52bd85L37-L38) [[2]](diffhunk://#diff-83788f5a048fe5dfe5c1fb462b014bae9b423de9d3a27b4bd3ace7805c52bd85L224-L225) [[3]](diffhunk://#diff-83788f5a048fe5dfe5c1fb462b014bae9b423de9d3a27b4bd3ace7805c52bd85L235-L238) [[4]](diffhunk://#diff-83788f5a048fe5dfe5c1fb462b014bae9b423de9d3a27b4bd3ace7805c52bd85L256-R248) [[5]](diffhunk://#diff-83788f5a048fe5dfe5c1fb462b014bae9b423de9d3a27b4bd3ace7805c52bd85L268-R258) [[6]](diffhunk://#diff-83788f5a048fe5dfe5c1fb462b014bae9b423de9d3a27b4bd3ace7805c52bd85L307-L317) [[7]](diffhunk://#diff-400ee09d447db714a4d68eff204d0f10a7057be851cf52ce0221ca7b74a3d9c9L14-L15)
* The star rating UI in `popup-window.component.html` now displays a maximum of 3 stars, and the descriptive labels for each intensity level have been updated to reflect the new scale. [[1]](diffhunk://#diff-7606c5558b6032fdd856d9f44772e9de7606ecd043a2cf002167285953fc42dcL79-R77) [[2]](diffhunk://#diff-7606c5558b6032fdd856d9f44772e9de7606ecd043a2cf002167285953fc42dcL32-R32)

**Bar Chart Display Improvements**

* The y-axis of the bar chart is now limited to the 0–5 range, with tick marks at integer steps and descriptive intensity labels for each tick (e.g., 'Very Weak', 'Moderate', etc.).
* Tooltips in the bar chart now show both the numeric value and its corresponding intensity label, rounded to the nearest level for clarity.

**Other Fixes**

* The timestamp conversion in `ScrollspyComponent` was corrected to avoid multiplying by 1000, ensuring proper date formatting.