### PR TITLE
refactor: simplify EmoReg retrieval by removing user data dependency

### DIFF
--- a/EmotionFrontend/src/app/reflect-history/reflect-history.component.ts
+++ b/EmotionFrontend/src/app/reflect-history/reflect-history.component.ts
@@ -15,7 +15,6 @@ export class ReflectHistoryComponent {
   filteredEmoReg: EmoReg[] = []; // Initialize the array to store EmoReg objects
   activeSection: number = 0;
   currentSectionNumber: number = 1;
-  userFirstName: string = '';
 
   constructor(
     private route: ActivatedRoute,
@@ -29,27 +28,13 @@ export class ReflectHistoryComponent {
       // Retrieve the 'a' parameter from the query parameters
       this.title = params['a'];
 
-      this.fetchUserDataAndEmoReg();
-
       // Call the function to retrieve EmoReg objects
-      // this.getEmoReg();
+      this.getEmoReg();
     });
   }
 
   setActiveSection(sectionIndex: number): void {
     this.activeSection = sectionIndex;
-  }
-
-  fetchUserDataAndEmoReg(): void {
-    this.emotionService.getUserData().subscribe({
-      next: (userData) => {
-        this.userFirstName = userData.firstName;  // directly use firstName field
-        this.getEmoReg();  // Once user is fetched, load EmoReg
-      },
-      error: (err) => {
-        console.error('Error fetching user data:', err);
-      }
-    });
   }
 
   sortReflectionsByTimestamp(): void {
@@ -61,14 +46,11 @@ export class ReflectHistoryComponent {
   getEmoReg(): void {
     this.emotionService.getEmoReg().subscribe(
       emoRegList => {
-        this.filteredEmoReg = emoRegList
-          .filter(emoReg => 
-            emoReg.GroupMembers?.toLowerCase().includes(this.userFirstName.toLowerCase())
-          )
-          .map(emoReg => ({
-            ...emoReg,
-            Timestamp: this.timeService.convertToDate(Number(emoReg.Timestamp))
-          }));
+        // Show all reflections for the community (no filtering by user)
+        this.filteredEmoReg = emoRegList.map(emoReg => ({
+          ...emoReg,
+          Timestamp: this.timeService.convertToDate(Number(emoReg.Timestamp))
+        }));
         this.sortReflectionsByTimestamp();
       },
       error => {


### PR DESCRIPTION
This pull request simplifies the logic in the `ReflectHistoryComponent` by removing user-specific filtering and related user data fetching. Now, all reflections for the community are shown, rather than filtering by the current user's first name.

**Refactoring to show all reflections and remove user filtering:**

* Removed the `userFirstName` property and the `fetchUserDataAndEmoReg` method, eliminating the need to fetch user data for filtering reflections. [[1]](diffhunk://#diff-0db057b56ad607e2dbd76f86c29f079fef24723f36d8f8f3cf7fb9a863dc1025L18) [[2]](diffhunk://#diff-0db057b56ad607e2dbd76f86c29f079fef24723f36d8f8f3cf7fb9a863dc1025L32-L54)
* Updated the `getEmoReg` method to display all reflections for the community without filtering by user, simplifying the logic and improving performance.